### PR TITLE
Adding a service

### DIFF
--- a/src/TemplateMapper.php
+++ b/src/TemplateMapper.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * @file
+ * Contains Drupal\template_mapper\TemplateMapper.
+ */
+
+namespace Drupal\template_mapper;
+
+/**
+ * Defines the Template mapper service.
+ *
+ * @todo, make an interface.
+ */
+class TemplateMapper {
+
+  public function performMapping($existing_suggestions, $hook) {
+    // @todo, this service should not be calling \Drupal. That defeats the
+    // purpose of a service.
+    $TemplateMapper =  \Drupal\template_mapper\Entity\TemplateMapper::load($hook);
+    // @todo Is there a better 'if' check to run?
+    if ($TemplateMapper) {
+      return $TemplateMapper->performMapping($existing_suggestions);
+    }
+    else {
+      return $existing_suggestions;
+    }
+  }
+}

--- a/template_mapper.module
+++ b/template_mapper.module
@@ -35,16 +35,7 @@ function template_mapper_theme() {
 /**
  * Implements hook_theme_suggestions_alter().
  */
-function template_mapper_theme_suggestions_alter(array &$suggestions, array
-$variables, $hook) {
-   // @todo, think about loading all template mappers into a service.
-   // That will avoid a ton of individual loads. Also, the code here does
-   // does not need to know anything about Entities.
-   $TemplateMapper =  \Drupal\template_mapper\Entity\TemplateMapper::load
-   ($hook);
-  // @todo Is there a better 'if' check to run?
-  if ($TemplateMapper) {
-
-    $suggestions = $TemplateMapper->performMapping($suggestions);
-  }
+function template_mapper_theme_suggestions_alter(array &$suggestions, array $variables, $hook) {
+  $template_mapper_service = \Drupal::service('template_mapper');
+  $suggestions = $template_mapper_service->performMapping($suggestions, $hook);
 }

--- a/template_mapper.services.yml
+++ b/template_mapper.services.yml
@@ -1,0 +1,3 @@
+services:
+  template_mapper:
+    class: Drupal\template_mapper\TemplateMapper


### PR DESCRIPTION
This PR adds a service. There is nearly no benefit to the service yet. The service class still calls \Drupal. The main reason I want this change now is because next I am going to rename the TemplateMapper entity to "TemplateMapping." It makes more grammatical sense for "mapping" to be the entity and "mapper" be the class that performs the action (replacing one template suggestion with another)
